### PR TITLE
fix(ushmm): update header pattern to handle multi-digit page numbers

### DIFF
--- a/ushmm/testimonies.py
+++ b/ushmm/testimonies.py
@@ -234,7 +234,7 @@ def remove_headers(text: str) -> str:
     str: The text without headers.
     """
     # Define the header pattern
-    header_pattern = re.compile(r'USHMM Archives RG-\d{2}\.\d{3}\*\d{4} \d', re.IGNORECASE)
+    header_pattern = re.compile(r'USHMM Archives RG-\d{2}\.\d{3}\*\d{4} \d+', re.IGNORECASE)
 
     # Find all headers in the text
     headers = header_pattern.findall(text)


### PR DESCRIPTION
Update the regular expression in ushmm.testimonies.remove_headers to capture headers with page numbers containing multiple digits.

- Changed '\d' to '\d+' at the end of the pattern
- This allows matching of page numbers with one or more digits
- Improves header removal for documents with 10+ pages

Closes #1